### PR TITLE
fix: Use default tls_certificate_name when certificate doesn't exist

### DIFF
--- a/sources/service-kubernetes/main.tf
+++ b/sources/service-kubernetes/main.tf
@@ -35,7 +35,7 @@ locals {
   ingress_rules = [for x in var.ingress_rules : {
     host            = x.host,
     path            = x.path,
-    tls_secret_name = kubernetes_secret.tls_certificate[x.host].metadata[0].name
+    tls_secret_name = lookup(kubernetes_secret.tls_certificate, x.host, null) == null ? "" : kubernetes_secret.tls_certificate[x.host].metadata[0].name
   }]
 }
 


### PR DESCRIPTION
This change is particularly helpful in `terraform destroy` situations, 
when `x.host` might be set to a default variable value rather than its 
original value.