### PR TITLE
feat: Update passive urls from passive.* to *-passive.*

### DIFF
--- a/sources/service-dns-cloudflare/main.tf
+++ b/sources/service-dns-cloudflare/main.tf
@@ -22,10 +22,15 @@ resource "cloudflare_record" "active_domain" {
 }
 
 resource "cloudflare_record" "passive_domain" {
-  for_each = local.passive_domains
+  for_each = { for y in local.passive_domains : y.name => {
+    name_pieces    = split(".", y.name)
+    value          = y.value
+    proxied        = y.proxied
+    hosted_zone_id = y.hosted_zone_id
+  } }
 
   zone_id = each.value.hosted_zone_id
-  name    = "passive.${each.value.name}"
+  name    = join(".", concat(["${each.value.name_pieces[0]}-passive"], length(each.value.name_pieces) > 1 ? slice(each.value.name_pieces, 1, length(each.value.name_pieces)) : []))
   value   = each.value.value
   type    = "CNAME"
   ttl     = 1


### PR DESCRIPTION
The following PR updates support for passive urls for deployed services. It switches from the previous naming convention of `passive.*` to `*-passive.*` in order to allow us to use our wild card SSL certs for each deployed environment `*.staging.` etc.

To support single host names we check the length of the split array and only concatenate if greater than 1.   